### PR TITLE
Fix: Backport upstream patch to prevent lib_crl semaphore SIGABRT

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -91,6 +91,7 @@ path = [
     "tdesktop/cur/*-Style-Opt-Round-message-size.patch",
     "tdesktop/cur/*-Fix-Always-use-bundled-TooManyCooks.patch",
     "tdesktop/cur/*-Fix-Disable-TooManyCooks-on-ARMv7.patch",
+    "tdesktop/cur/*-Fix-lib_crl-semaphore-SIGABRT.patch",
 ]
 SPDX-License-Identifier = "GPL-3.0-or-later WITH LicenseRef-sqlitestudio-OpenSSL-exception"
 SPDX-FileCopyrightText = "Yukigram contributors <https://github.com/yukigram/yukigram>"

--- a/tdesktop/cur/0107-Fix-lib_crl-semaphore-SIGABRT.patch
+++ b/tdesktop/cur/0107-Fix-lib_crl-semaphore-SIGABRT.patch
@@ -1,0 +1,226 @@
+From 28b523dae25214bf56a00140ad8a60ca115ebeba Mon Sep 17 00:00:00 2001
+From: John Preston <johnprestonmail@gmail.com>
+Date: Tue, 16 Jun 2026 22:01:31 +0400
+Subject: [PATCH] Use wait on std::atomic for semaphore (non-macOS).
+
+---
+ CMakeLists.txt                      |  2 --
+ crl/common/crl_common_semaphore.h   | 31 ++++++++++++++++---
+ crl/crl_semaphore.h                 | 18 ++++++++---
+ crl/winapi/crl_winapi_list.h        |  2 ++
+ crl/winapi/crl_winapi_semaphore.cpp | 39 ------------------------
+ crl/winapi/crl_winapi_semaphore.h   | 47 -----------------------------
+ 6 files changed, 43 insertions(+), 96 deletions(-)
+ delete mode 100644 crl/winapi/crl_winapi_semaphore.cpp
+ delete mode 100644 crl/winapi/crl_winapi_semaphore.h
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 87ead0d..78a42a2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -45,8 +45,6 @@ PRIVATE
+     crl/winapi/crl_winapi_fp_exceptions.cpp
+     crl/winapi/crl_winapi_list.cpp
+     crl/winapi/crl_winapi_list.h
+-    crl/winapi/crl_winapi_semaphore.cpp
+-    crl/winapi/crl_winapi_semaphore.h
+     crl/winapi/crl_winapi_time.cpp
+     crl/winapi/crl_winapi_windows_h.h
+     crl/crl.h
+diff --git a/crl/common/crl_common_semaphore.h b/crl/common/crl_common_semaphore.h
+index 28c9bb9..b3da55a 100644
+--- a/crl/common/crl_common_semaphore.h
++++ b/crl/common/crl_common_semaphore.h
+@@ -8,10 +8,29 @@
+ 
+ #include <crl/common/crl_common_config.h>
+ 
+-#include <semaphore>
++#include <atomic>
+ 
+ namespace crl {
+ 
++// A lightweight wake/notify primitive: a saturating, auto-reset event with
++// a single waiter. release() raises the signal and is coalescing - repeated
++// release() calls before the waiter consumes the signal collapse into one,
++// they never accumulate and never overflow. acquire() waits for the signal
++// and consumes it.
++//
++// This intentionally is not a counting semaphore. Every use in the codebase
++// is either a one-shot "block until the async task finished" handshake or a
++// "wake the worker thread so it re-checks its state" notification, and the
++// latter must tolerate redundant wakes coming from several sources at once.
++//
++// Backed by std::atomic<bool>::wait/notify, which lowers to the lightest
++// wait primitive the OS provides (WaitOnAddress on Windows 8+, futex on
++// Linux): no kernel handle, no allocation, userspace fast path. On Windows 7
++// the MSVC runtime falls back to a wait table - still correct, just heavier.
++//
++// Not used on Apple: std::atomic<>::wait is availability-gated to macOS 11.0
++// in libc++, while we target 10.13+, so crl_semaphore.h selects a
++// dispatch_semaphore backend there instead.
+ class semaphore {
+ public:
+ 	semaphore() = default;
+@@ -21,14 +40,18 @@ class semaphore {
+ 	semaphore &operator=(semaphore &&other) = delete;
+ 
+ 	void acquire() {
+-		_impl.acquire();
++		while (!_signaled.exchange(false, std::memory_order_acquire)) {
++			_signaled.wait(false, std::memory_order_relaxed);
++		}
+ 	}
+ 	void release() {
+-		_impl.release();
++		if (!_signaled.exchange(true, std::memory_order_release)) {
++			_signaled.notify_one();
++		}
+ 	}
+ 
+ private:
+-	std::binary_semaphore _impl{0};
++	std::atomic<bool> _signaled = false;
+ 
+ };
+ 
+diff --git a/crl/crl_semaphore.h b/crl/crl_semaphore.h
+index 9e217a7..d86f2d5 100644
+--- a/crl/crl_semaphore.h
++++ b/crl/crl_semaphore.h
+@@ -8,10 +8,20 @@
+ 
+ #include <crl/common/crl_common_config.h>
+ 
+-#if defined CRL_USE_WINAPI
+-#include <crl/winapi/crl_winapi_semaphore.h>
+-#elif defined CRL_USE_DISPATCH // CRL_USE_WINAPI
++// crl::semaphore is a lightweight wake/notify primitive.
++//
++// Everywhere except Apple it is a single std::atomic-based saturating event
++// (see crl_common_semaphore.h), which lowers to the lightest OS wait
++// primitive available: WaitOnAddress on Windows 8+, futex on Linux. On older
++// Windows (7) the MSVC runtime transparently falls back to a wait table - it
++// still compiles and runs.
++//
++// On Apple we keep a dispatch_semaphore backend: std::atomic<>::wait and
++// std::counting_semaphore are availability-gated to macOS 11.0 in libc++
++// (the wait/notify machinery lives in the dylib), while we still target
++// macOS 10.13+. dispatch_semaphore is available since macOS 10.6.
++#if defined CRL_USE_DISPATCH
+ #include <crl/dispatch/crl_dispatch_semaphore.h>
+ #else // CRL_USE_DISPATCH
+ #include <crl/common/crl_common_semaphore.h>
+-#endif // !CRL_USE_WINAPI && !CRL_USE_DISPATCH
++#endif // !CRL_USE_DISPATCH
+diff --git a/crl/winapi/crl_winapi_list.h b/crl/winapi/crl_winapi_list.h
+index d405e6d..ada6066 100644
+--- a/crl/winapi/crl_winapi_list.h
++++ b/crl/winapi/crl_winapi_list.h
+@@ -13,6 +13,8 @@
+ #include <crl/common/crl_common_utils.h>
+ #include <crl/crl_semaphore.h>
+ 
++#include <memory>
++
+ #ifndef CRL_USE_WINAPI
+ #error "This file should not be included by client-code directly."
+ #endif // CRL_USE_WINAPI
+diff --git a/crl/winapi/crl_winapi_semaphore.cpp b/crl/winapi/crl_winapi_semaphore.cpp
+deleted file mode 100644
+index 2e98880..0000000
+--- a/crl/winapi/crl_winapi_semaphore.cpp
++++ /dev/null
+@@ -1,39 +0,0 @@
+-// This file is part of Desktop App Toolkit,
+-// a set of libraries for developing nice desktop applications.
+-//
+-// For license and copyright information please follow this link:
+-// https://github.com/desktop-app/legal/blob/master/LEGAL
+-//
+-#include <crl/winapi/crl_winapi_semaphore.h>
+-
+-#ifdef CRL_USE_WINAPI
+-
+-#include <crl/winapi/crl_winapi_windows_h.h>
+-
+-namespace crl {
+-
+-auto semaphore::implementation::create() -> pointer {
+-	auto result = CreateSemaphore(nullptr, 0, 1, nullptr);
+-	if (!result) {
+-		std::terminate();
+-	}
+-	return result;
+-}
+-
+-void semaphore::implementation::operator()(pointer value) {
+-	if (value) {
+-		CloseHandle(value);
+-	}
+-};
+-
+-void semaphore::acquire() {
+-	WaitForSingleObject(_handle.get(), INFINITE);
+-}
+-
+-void semaphore::release() {
+-	ReleaseSemaphore(_handle.get(), 1, nullptr);
+-}
+-
+-} // namespace crl
+-
+-#endif // CRL_USE_WINAPI
+diff --git a/crl/winapi/crl_winapi_semaphore.h b/crl/winapi/crl_winapi_semaphore.h
+deleted file mode 100644
+index 234c8de..0000000
+--- a/crl/winapi/crl_winapi_semaphore.h
++++ /dev/null
+@@ -1,47 +0,0 @@
+-// This file is part of Desktop App Toolkit,
+-// a set of libraries for developing nice desktop applications.
+-//
+-// For license and copyright information please follow this link:
+-// https://github.com/desktop-app/legal/blob/master/LEGAL
+-//
+-#pragma once
+-
+-#include <crl/common/crl_common_config.h>
+-
+-#ifdef CRL_USE_WINAPI
+-
+-#include <memory>
+-
+-namespace crl {
+-
+-class semaphore {
+-public:
+-	semaphore() : _handle(implementation::create()) {
+-	}
+-	semaphore(const semaphore &other) = delete;
+-	semaphore &operator=(const semaphore &other) = delete;
+-	semaphore(semaphore &&other) noexcept
+-	: _handle(std::move(other._handle)) {
+-	}
+-	semaphore &operator=(semaphore &&other) noexcept {
+-		_handle = std::move(other._handle);
+-		return *this;
+-	}
+-
+-	void acquire();
+-	void release();
+-
+-private:
+-	// Hide WinAPI HANDLE
+-	struct implementation {
+-		using pointer = void*;
+-		static pointer create();
+-		void operator()(pointer value);
+-	};
+-	std::unique_ptr<implementation::pointer, implementation> _handle;
+-
+-};
+-
+-} // namespace crl
+-
+-#endif // CRL_USE_WINAPI

--- a/tdesktop/cur/0109-Fix-lib_crl-semaphore-SIGABRT.patch
+++ b/tdesktop/cur/0109-Fix-lib_crl-semaphore-SIGABRT.patch
@@ -1,35 +1,25 @@
-From 28b523dae25214bf56a00140ad8a60ca115ebeba Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: John Preston <johnprestonmail@gmail.com>
 Date: Tue, 16 Jun 2026 22:01:31 +0400
-Subject: [PATCH] Use wait on std::atomic for semaphore (non-macOS).
+Subject: [PATCH] Fix: lib_crl semaphore SIGABRT
 
----
- Telegram/lib_crl/CMakeLists.txt               |   2 --
- Telegram/lib_crl/crl/common/crl_common_semaphore.h |  31 ++++++++++++++++
- Telegram/lib_crl/crl/crl_semaphore.h               |  18 ++++++++--
- Telegram/lib_crl/crl/winapi/crl_winapi_list.h      |   2 ++
- Telegram/lib_crl/crl/winapi/crl_winapi_semaphore.cpp |  39 --------------------
- Telegram/lib_crl/crl/winapi/crl_winapi_semaphore.h   |  47 ------------------------
- 6 files changed, 48 insertions(+), 91 deletions(-)
- delete mode 100644 Telegram/lib_crl/crl/winapi/crl_winapi_semaphore.cpp
- delete mode 100644 Telegram/lib_crl/crl/winapi/crl_winapi_semaphore.h
+Backports upstream lib_crl fix.
 
 diff --git a/Telegram/lib_crl/CMakeLists.txt b/Telegram/lib_crl/CMakeLists.txt
-index 87ead0d..78a42a2 100644
+index 0b8bf214bd..b6c60a02c2 100644
 --- a/Telegram/lib_crl/CMakeLists.txt
 +++ b/Telegram/lib_crl/CMakeLists.txt
 @@ -45,8 +45,6 @@ PRIVATE
- 
- 	crl/winapi/crl_winapi_fp_exceptions.cpp
- 	crl/winapi/crl_winapi_list.cpp
--	crl/winapi/crl_winapi_list.h
--	crl/winapi/crl_winapi_semaphore.cpp
--	crl/winapi/crl_winapi_semaphore.h
- 	crl/winapi/crl_winapi_time.cpp
- 
- 	crl/winapi/crl_winapi_windows_h.h
+     crl/winapi/crl_winapi_fp_exceptions.cpp
+     crl/winapi/crl_winapi_list.cpp
+     crl/winapi/crl_winapi_list.h
+-    crl/winapi/crl_winapi_semaphore.cpp
+-    crl/winapi/crl_winapi_semaphore.h
+     crl/winapi/crl_winapi_time.cpp
+     crl/winapi/crl_winapi_windows_h.h
+     crl/crl.h
 diff --git a/Telegram/lib_crl/crl/common/crl_common_semaphore.h b/Telegram/lib_crl/crl/common/crl_common_semaphore.h
-index 28c9bb9..b3da55a 100644
+index 28c9bb9b1c..b3da55a4b1 100644
 --- a/Telegram/lib_crl/crl/common/crl_common_semaphore.h
 +++ b/Telegram/lib_crl/crl/common/crl_common_semaphore.h
 @@ -8,10 +8,29 @@
@@ -63,7 +53,7 @@ index 28c9bb9..b3da55a 100644
  class semaphore {
  public:
  	semaphore() = default;
-@@ -20,13 +39,17 @@ public:
+@@ -21,14 +40,18 @@ public:
  	semaphore &operator=(semaphore &&other) = delete;
  
  	void acquire() {
@@ -80,12 +70,13 @@ index 28c9bb9..b3da55a 100644
  	}
  
  private:
--	std::binary_semaphore _impl{ 0 };
+-	std::binary_semaphore _impl{0};
 +	std::atomic<bool> _signaled = false;
  
  };
+ 
 diff --git a/Telegram/lib_crl/crl/crl_semaphore.h b/Telegram/lib_crl/crl/crl_semaphore.h
-index 9e217a7..d86f2d5 100644
+index 9e217a75cf..d86f2d5136 100644
 --- a/Telegram/lib_crl/crl/crl_semaphore.h
 +++ b/Telegram/lib_crl/crl/crl_semaphore.h
 @@ -8,10 +8,20 @@
@@ -109,12 +100,12 @@ index 9e217a7..d86f2d5 100644
 +// macOS 10.13+. dispatch_semaphore is available since macOS 10.6.
 +#if defined CRL_USE_DISPATCH
  #include <crl/dispatch/crl_dispatch_semaphore.h>
--#else // CRL_USE_WINAPI && !CRL_USE_DISPATCH
-+#else // CRL_USE_DISPATCH
+ #else // CRL_USE_DISPATCH
  #include <crl/common/crl_common_semaphore.h>
--#endif // CRL_USE_WINAPI && !CRL_USE_DISPATCH
+-#endif // !CRL_USE_WINAPI && !CRL_USE_DISPATCH
++#endif // !CRL_USE_DISPATCH
 diff --git a/Telegram/lib_crl/crl/winapi/crl_winapi_list.h b/Telegram/lib_crl/crl/winapi/crl_winapi_list.h
-index d405e6d..ada6066 100644
+index d405e6dbe2..ada6066ab8 100644
 --- a/Telegram/lib_crl/crl/winapi/crl_winapi_list.h
 +++ b/Telegram/lib_crl/crl/winapi/crl_winapi_list.h
 @@ -13,6 +13,8 @@
@@ -128,7 +119,7 @@ index d405e6d..ada6066 100644
  #endif // CRL_USE_WINAPI
 diff --git a/Telegram/lib_crl/crl/winapi/crl_winapi_semaphore.cpp b/Telegram/lib_crl/crl/winapi/crl_winapi_semaphore.cpp
 deleted file mode 100644
-index 2e98880..0000000
+index 2e9888033f..0000000000
 --- a/Telegram/lib_crl/crl/winapi/crl_winapi_semaphore.cpp
 +++ /dev/null
 @@ -1,39 +0,0 @@
@@ -158,7 +149,7 @@ index 2e98880..0000000
 -	if (value) {
 -		CloseHandle(value);
 -	}
--}
+-};
 -
 -void semaphore::acquire() {
 -	WaitForSingleObject(_handle.get(), INFINITE);
@@ -173,7 +164,7 @@ index 2e98880..0000000
 -#endif // CRL_USE_WINAPI
 diff --git a/Telegram/lib_crl/crl/winapi/crl_winapi_semaphore.h b/Telegram/lib_crl/crl/winapi/crl_winapi_semaphore.h
 deleted file mode 100644
-index 234c8de..0000000
+index 234c8de003..0000000000
 --- a/Telegram/lib_crl/crl/winapi/crl_winapi_semaphore.h
 +++ /dev/null
 @@ -1,47 +0,0 @@
@@ -195,10 +186,8 @@ index 234c8de..0000000
 -
 -class semaphore {
 -public:
--	semaphore()
--	: _handle(implementation::create()) {
+-	semaphore() : _handle(implementation::create()) {
 -	}
--
 -	semaphore(const semaphore &other) = delete;
 -	semaphore &operator=(const semaphore &other) = delete;
 -	semaphore(semaphore &&other) noexcept

--- a/tdesktop/cur/0109-Fix-lib_crl-semaphore-SIGABRT.patch
+++ b/tdesktop/cur/0109-Fix-lib_crl-semaphore-SIGABRT.patch
@@ -4,33 +4,34 @@ Date: Tue, 16 Jun 2026 22:01:31 +0400
 Subject: [PATCH] Use wait on std::atomic for semaphore (non-macOS).
 
 ---
- CMakeLists.txt                      |  2 --
- crl/common/crl_common_semaphore.h   | 31 ++++++++++++++++---
- crl/crl_semaphore.h                 | 18 ++++++++---
- crl/winapi/crl_winapi_list.h        |  2 ++
- crl/winapi/crl_winapi_semaphore.cpp | 39 ------------------------
- crl/winapi/crl_winapi_semaphore.h   | 47 -----------------------------
- 6 files changed, 43 insertions(+), 96 deletions(-)
- delete mode 100644 crl/winapi/crl_winapi_semaphore.cpp
- delete mode 100644 crl/winapi/crl_winapi_semaphore.h
+ Telegram/lib_crl/CMakeLists.txt               |   2 --
+ Telegram/lib_crl/crl/common/crl_common_semaphore.h |  31 ++++++++++++++++
+ Telegram/lib_crl/crl/crl_semaphore.h               |  18 ++++++++--
+ Telegram/lib_crl/crl/winapi/crl_winapi_list.h      |   2 ++
+ Telegram/lib_crl/crl/winapi/crl_winapi_semaphore.cpp |  39 --------------------
+ Telegram/lib_crl/crl/winapi/crl_winapi_semaphore.h   |  47 ------------------------
+ 6 files changed, 48 insertions(+), 91 deletions(-)
+ delete mode 100644 Telegram/lib_crl/crl/winapi/crl_winapi_semaphore.cpp
+ delete mode 100644 Telegram/lib_crl/crl/winapi/crl_winapi_semaphore.h
 
-diff --git a/CMakeLists.txt b/CMakeLists.txt
+diff --git a/Telegram/lib_crl/CMakeLists.txt b/Telegram/lib_crl/CMakeLists.txt
 index 87ead0d..78a42a2 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
+--- a/Telegram/lib_crl/CMakeLists.txt
++++ b/Telegram/lib_crl/CMakeLists.txt
 @@ -45,8 +45,6 @@ PRIVATE
-     crl/winapi/crl_winapi_fp_exceptions.cpp
-     crl/winapi/crl_winapi_list.cpp
-     crl/winapi/crl_winapi_list.h
--    crl/winapi/crl_winapi_semaphore.cpp
--    crl/winapi/crl_winapi_semaphore.h
-     crl/winapi/crl_winapi_time.cpp
-     crl/winapi/crl_winapi_windows_h.h
-     crl/crl.h
-diff --git a/crl/common/crl_common_semaphore.h b/crl/common/crl_common_semaphore.h
+ 
+ 	crl/winapi/crl_winapi_fp_exceptions.cpp
+ 	crl/winapi/crl_winapi_list.cpp
+-	crl/winapi/crl_winapi_list.h
+-	crl/winapi/crl_winapi_semaphore.cpp
+-	crl/winapi/crl_winapi_semaphore.h
+ 	crl/winapi/crl_winapi_time.cpp
+ 
+ 	crl/winapi/crl_winapi_windows_h.h
+diff --git a/Telegram/lib_crl/crl/common/crl_common_semaphore.h b/Telegram/lib_crl/crl/common/crl_common_semaphore.h
 index 28c9bb9..b3da55a 100644
---- a/crl/common/crl_common_semaphore.h
-+++ b/crl/common/crl_common_semaphore.h
+--- a/Telegram/lib_crl/crl/common/crl_common_semaphore.h
++++ b/Telegram/lib_crl/crl/common/crl_common_semaphore.h
 @@ -8,10 +8,29 @@
  
  #include <crl/common/crl_common_config.h>
@@ -62,7 +63,7 @@ index 28c9bb9..b3da55a 100644
  class semaphore {
  public:
  	semaphore() = default;
-@@ -21,14 +40,18 @@ class semaphore {
+@@ -20,13 +39,17 @@ public:
  	semaphore &operator=(semaphore &&other) = delete;
  
  	void acquire() {
@@ -79,15 +80,14 @@ index 28c9bb9..b3da55a 100644
  	}
  
  private:
--	std::binary_semaphore _impl{0};
+-	std::binary_semaphore _impl{ 0 };
 +	std::atomic<bool> _signaled = false;
  
  };
- 
-diff --git a/crl/crl_semaphore.h b/crl/crl_semaphore.h
+diff --git a/Telegram/lib_crl/crl/crl_semaphore.h b/Telegram/lib_crl/crl/crl_semaphore.h
 index 9e217a7..d86f2d5 100644
---- a/crl/crl_semaphore.h
-+++ b/crl/crl_semaphore.h
+--- a/Telegram/lib_crl/crl/crl_semaphore.h
++++ b/Telegram/lib_crl/crl/crl_semaphore.h
 @@ -8,10 +8,20 @@
  
  #include <crl/common/crl_common_config.h>
@@ -109,14 +109,14 @@ index 9e217a7..d86f2d5 100644
 +// macOS 10.13+. dispatch_semaphore is available since macOS 10.6.
 +#if defined CRL_USE_DISPATCH
  #include <crl/dispatch/crl_dispatch_semaphore.h>
- #else // CRL_USE_DISPATCH
+-#else // CRL_USE_WINAPI && !CRL_USE_DISPATCH
++#else // CRL_USE_DISPATCH
  #include <crl/common/crl_common_semaphore.h>
--#endif // !CRL_USE_WINAPI && !CRL_USE_DISPATCH
-+#endif // !CRL_USE_DISPATCH
-diff --git a/crl/winapi/crl_winapi_list.h b/crl/winapi/crl_winapi_list.h
+-#endif // CRL_USE_WINAPI && !CRL_USE_DISPATCH
+diff --git a/Telegram/lib_crl/crl/winapi/crl_winapi_list.h b/Telegram/lib_crl/crl/winapi/crl_winapi_list.h
 index d405e6d..ada6066 100644
---- a/crl/winapi/crl_winapi_list.h
-+++ b/crl/winapi/crl_winapi_list.h
+--- a/Telegram/lib_crl/crl/winapi/crl_winapi_list.h
++++ b/Telegram/lib_crl/crl/winapi/crl_winapi_list.h
 @@ -13,6 +13,8 @@
  #include <crl/common/crl_common_utils.h>
  #include <crl/crl_semaphore.h>
@@ -126,10 +126,10 @@ index d405e6d..ada6066 100644
  #ifndef CRL_USE_WINAPI
  #error "This file should not be included by client-code directly."
  #endif // CRL_USE_WINAPI
-diff --git a/crl/winapi/crl_winapi_semaphore.cpp b/crl/winapi/crl_winapi_semaphore.cpp
+diff --git a/Telegram/lib_crl/crl/winapi/crl_winapi_semaphore.cpp b/Telegram/lib_crl/crl/winapi/crl_winapi_semaphore.cpp
 deleted file mode 100644
 index 2e98880..0000000
---- a/crl/winapi/crl_winapi_semaphore.cpp
+--- a/Telegram/lib_crl/crl/winapi/crl_winapi_semaphore.cpp
 +++ /dev/null
 @@ -1,39 +0,0 @@
 -// This file is part of Desktop App Toolkit,
@@ -158,7 +158,7 @@ index 2e98880..0000000
 -	if (value) {
 -		CloseHandle(value);
 -	}
--};
+-}
 -
 -void semaphore::acquire() {
 -	WaitForSingleObject(_handle.get(), INFINITE);
@@ -171,10 +171,10 @@ index 2e98880..0000000
 -} // namespace crl
 -
 -#endif // CRL_USE_WINAPI
-diff --git a/crl/winapi/crl_winapi_semaphore.h b/crl/winapi/crl_winapi_semaphore.h
+diff --git a/Telegram/lib_crl/crl/winapi/crl_winapi_semaphore.h b/Telegram/lib_crl/crl/winapi/crl_winapi_semaphore.h
 deleted file mode 100644
 index 234c8de..0000000
---- a/crl/winapi/crl_winapi_semaphore.h
+--- a/Telegram/lib_crl/crl/winapi/crl_winapi_semaphore.h
 +++ /dev/null
 @@ -1,47 +0,0 @@
 -// This file is part of Desktop App Toolkit,
@@ -195,8 +195,10 @@ index 234c8de..0000000
 -
 -class semaphore {
 -public:
--	semaphore() : _handle(implementation::create()) {
+-	semaphore()
+-	: _handle(implementation::create()) {
 -	}
+-
 -	semaphore(const semaphore &other) = delete;
 -	semaphore &operator=(const semaphore &other) = delete;
 -	semaphore(semaphore &&other) noexcept


### PR DESCRIPTION
This patch backports the upstream `lib_crl` fix to resolve a critical assertion failure (`std::counting_semaphore` over-release) triggered during bulk media teardown.

The crash specifically affects Linux distributions with hardened `libstdc++` (such as Arch Linux with `_GLIBCXX_ASSERTIONS` enabled) when exiting views containing multiple media streams, like the "Recent Actions" page, or upon finishing audio playback.

**References:**
* Upstream commit: https://github.com/desktop-app/lib_crl/commit/28b523d
* Upstream issue: https://github.com/telegramdesktop/tdesktop/issues/30840

**Note for Maintainers:**
This is a direct backport from upstream. It must be dropped when the base `tdesktop` source is upgraded to version 6.9.4 or later.