### PR TITLE
feat: show custom title in group call bar

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -171,6 +171,7 @@ These are placed under `(Major)` category.
 - :gear: Custom monospace font
 - Video controls for GIFs
 - :zap: :gear: Disable SHOUTING CASE on buttons
+- Show custom title in group call bar
 
 These are placed under `(Interface)` category.
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -94,6 +94,8 @@ path = [
     "tdesktop/cur/*-Fix-Fit-media-preview-to-window-size.patch",
     "tdesktop/cur/*-Fix-setBadgeNumber-bug-workaround.patch",
     "tdesktop/cur/*-Fix-lib_crl-semaphore-SIGABRT.patch",
+    "tdesktop/cur/*-Interface-Show-custom-title-in-group-call-bar.patch",
+
 ]
 SPDX-License-Identifier = "GPL-3.0-or-later WITH LicenseRef-sqlitestudio-OpenSSL-exception"
 SPDX-FileCopyrightText = "Yukigram contributors <https://github.com/yukigram/yukigram>"

--- a/tdesktop/cur/0110-Interface-Show-custom-title-in-group-call-bar.patch
+++ b/tdesktop/cur/0110-Interface-Show-custom-title-in-group-call-bar.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zoh-li <i@zoh.li>
+Date: Sun, 21 Jun 2026 15:44:21 +0330
+Subject: [PATCH] (Interface) Show custom title in group call bar
+
+
+diff --git a/Telegram/SourceFiles/ui/chat/group_call_bar.cpp b/Telegram/SourceFiles/ui/chat/group_call_bar.cpp
+index 13481b99dd..db62cde0b8 100644
+--- a/Telegram/SourceFiles/ui/chat/group_call_bar.cpp
++++ b/Telegram/SourceFiles/ui/chat/group_call_bar.cpp
+@@ -293,17 +293,17 @@ void GroupCallBar::paintTitleAndStatus(Painter &p) {
+ 		left,
+ 		titleTop,
+ 		width,
+-		(!_content.scheduleDate
++		(!_content.title.isEmpty()
++			? ((titleWidth > available)
++				? font->elided(_content.title, available)
++				: _content.title)
++			: !_content.scheduleDate
+ 			? (_content.livestream
+ 				? tr::lng_group_call_title_channel
+ 				: tr::lng_group_call_title)(tr::now)
+-			: _content.title.isEmpty()
+-			? (_content.livestream
++			: (_content.livestream
+ 				? tr::lng_group_call_scheduled_title_channel
+-				: tr::lng_group_call_scheduled_title)(tr::now)
+-			: (titleWidth > available)
+-			? font->elided(_content.title, available)
+-			: _content.title));
++				: tr::lng_group_call_scheduled_title)(tr::now)));
+ 	p.setPen(st::historyStatusFg);
+ 	p.setFont(st::defaultMessageBar.text.font);
+ 	const auto when = [&] {


### PR DESCRIPTION
This patch fixes a UI logic flaw where the custom title of an active group call was being unconditionally overridden by default translation strings "Video Chat".

The rendering logic in `GroupCallBar::paintTitleAndStatus` has been restructured to prioritize the user-defined `_content.title`. The default strings are now strictly used as a fallback when the custom title is empty.

### Visual Changes

#### Before:
<img width="563" height="101" alt="Screenshot_20260621_154211-1" src="https://github.com/user-attachments/assets/bb4f3630-e9cd-41fa-a0c4-951c7a84c56b" />

#### After:
<img width="563" height="98" alt="Screenshot_20260621_154227" src="https://github.com/user-attachments/assets/8d0bf4d8-c916-4a5e-8ee4-875f92df97d2" />